### PR TITLE
Add advanced option to prevent loading kernel modules

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -1479,7 +1479,7 @@ int check_for_unloaded_kernel_module(Options *op)
      * kernel and only installing a kernel module.
      */
 
-    if (op->kernel_module_only && op->kernel_name) {
+    if (op->skip_module_load || (op->kernel_module_only && op->kernel_name)) {
         ui_log(op, "Only installing a kernel module for a non-running "
                "kernel; skipping the \"is an NVIDIA kernel module loaded?\" "
                "test.");

--- a/nvidia-installer.c
+++ b/nvidia-installer.c
@@ -307,6 +307,8 @@ static void parse_commandline(int argc, char *argv[], Options *op)
             op->kernel_module_installation_path = strval; break;
         case UNINSTALL_OPTION:
             op->uninstall = TRUE; break;
+        case SKIP_MODULE_LOAD_OPTION:
+            op->skip_module_load = TRUE; break;
         case SKIP_MODULE_UNLOAD_OPTION:
             op->skip_module_unload = TRUE; break;
         case PROC_MOUNT_POINT_OPTION:

--- a/option_table.h
+++ b/option_table.h
@@ -41,6 +41,7 @@ enum {
     KERNEL_INCLUDE_PATH_OPTION,
     KERNEL_INSTALL_PATH_OPTION,
     UNINSTALL_OPTION,
+    SKIP_MODULE_LOAD_OPTION,
     SKIP_MODULE_UNLOAD_OPTION,
     PROC_MOUNT_POINT_OPTION,
     USER_INTERFACE_OPTION,
@@ -141,6 +142,11 @@ static const NVGetoptOption __options[] = {
 
     { "uninstall", UNINSTALL_OPTION, 0, NULL,
       "Uninstall the currently installed NVIDIA driver." },
+
+    { "skip-module-load", SKIP_MODULE_LOAD_OPTION, 0, NULL,
+      "When installing the driver, skip loading of the NVIDIA kernel "
+      "module. The kernel module will not be loaded, even to test it. "
+      "Modules built for non-running kernels will never be loaded." },
 
     { "skip-module-unload", SKIP_MODULE_UNLOAD_OPTION,
       NVGETOPT_OPTION_APPLIES_TO_NVIDIA_UNINSTALL, NULL,


### PR DESCRIPTION
Occasionally, it is desirable to install NVIDIA drivers on systems without NVIDIA hardware present. One use-case for this is creating machine images for computer clusters. These images may be built on desktops without GPUs, or they may be built in virtual environments. As far as I can determine, this is difficult to achieve with the current nvidia-installer.

In previous versions, the installer would always try to load the kernel module if it was built for the running kernel. This operation fails when no NVIDIA hardware is present, preventing installation.

This PR adds a `--skip-module-load` option to the installer, which will directly set the option variable of the same name. The new option complements the existing `--skip-module-unload` option.

The new option suppresses all module loading, everywhere. It allows installation to complete on systems which do not have NVIDIA hardware connected at install-time.

---
I also submitted this as a patch to <linux-bugs@nvidia.com>, but I am not sure if this project prefers to receive patches or PRs.
