### PR TITLE
fix: use references/pointers for large objects

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -830,8 +830,8 @@ static int pack_kernel_interface(Options *op, Package *p,
 
 
 static void handle_optional_module_failure(Options *op,
-                                           KernelModuleInfo module,
-                                           const char *action) {
+                                            KernelModuleInfo *module,
+                                            const char *action) {
     if (module.is_optional) {
         ui_error(op, "The %s kernel module failed to %s. This kernel module "
                  "is required for the proper operation of %s. If you do not "
@@ -2413,7 +2413,7 @@ int remove_kernel_module_from_package(Package *p, const char *module)
 }
 
 
-void free_kernel_module_info(KernelModuleInfo info)
+void free_kernel_module_info(const KernelModuleInfo &info)
 {
     nvfree(info.module_name);
     nvfree(info.module_filename);

--- a/precompiled.c
+++ b/precompiled.c
@@ -653,7 +653,7 @@ void free_precompiled(PrecompiledInfo *info)
 
 
 
-void free_precompiled_file_data(PrecompiledFileInfo fileInfo)
+void free_precompiled_file_data(const PrecompiledFileInfo &fileInfo)
 {
     nvfree(fileInfo.name);
     nvfree(fileInfo.linked_module_name);


### PR DESCRIPTION
The PrecompiledFileInfo and KernelModuleInfo objects are both 72 bytes, well above the 64 byte limit that C should work with. Working with large objects like that on the stack can cause various problems to arise.

This PR uses references/pointers for those aforementioned objects.