### PR TITLE
Fix incorrect condition in initramfs_tool_helper() path argument handling

### DIFF
--- a/initramfs.c
+++ b/initramfs.c
@@ -364,15 +364,16 @@ static int initramfs_tool_helper(Options *op, int tool, const char *kernel,
     }
 
     /* Build initramfs file path specific command line arguments */
-    if (path && initramfs_tools[tool].path_specific_args) {
-        if (!initramfs_tools[tool].path_specific_args) {
+    if (path) {
+        if (initramfs_tools[tool].path_specific_args) {
+            path_args = nvstrcat(initramfs_tools[tool].path_specific_args, " ",
+                                 path, NULL);
+        } else {
             ui_log(op, "%s does not take a path argument.", tool_path);
             goto done;
         }
-        path_args = nvstrcat(initramfs_tools[tool].path_specific_args, " ",
-                             path, NULL);
     } else {
-        if (initramfs_tools[tool].requires_path || !path) {
+        if (initramfs_tools[tool].requires_path) {
             ui_log(op, "%s requires a file path argument, but none was given.",
                    tool_path);
             goto done;


### PR DESCRIPTION
Fix a logic error in `initramfs_tool_helper()` where the path argument handling used a single `if/else` with a combined outer condition `if (path && path_specific_args)`, causing two distinct issues:

1. **Spurious warning in the common case:**
When the tool is `update-initramfs` (`path_specific_args = NULL`, `requires_path = FALSE`) and an initramfs image such as `/boot/initrd.img-<kernel>` exists, the first attempt always falls through to the `else` branch where `!path` evaluates to true (since `path` is `NULL` on the first call), producing a misleading warning:
`"/usr/sbin/update-initramfs requires a file path argument, but none was given."`
The command only actually runs on the second attempt.
2. **Complete failure in less common configurations:**
When executed on a machine where `/boot` contains only `initrd.img` without a kernel-versioned suffix, `get_initramfs_path()` returns `NULL` for all attempts. Since the `else` branch condition `requires_path || !path` is always true when `path` is `NULL`, all 4 retry attempts emit the same warning and `update-initramfs` is never executed, resulting in:
`"Failed to rebuild the initramfs!"`.

This also removes a dead code path where `!path_specific_args` was checked inside a block that already required `path_specific_args` to be non-NULL.

I've built nvidia-installer and tested this fix myself, and `update-initramfs -u` executes successfully on the first
attempt in both scenarios described above.